### PR TITLE
Update Laser.

### DIFF
--- a/OpenRA.Mods.Kknd/Graphics/LaserRenderable.cs
+++ b/OpenRA.Mods.Kknd/Graphics/LaserRenderable.cs
@@ -17,12 +17,12 @@ namespace OpenRA.Mods.Kknd.Graphics
 {
 	public struct LaserRenderable : IRenderable, IFinalizedRenderable
 	{
-		readonly int2[] offsets;
+		readonly WPos[] offsets;
 		readonly int zOffset;
 		readonly WDist width;
 		readonly Color color;
 
-		public LaserRenderable(int2[] offsets, int zOffset, WDist width, Color color)
+		public LaserRenderable(WPos[] offsets, int zOffset, WDist width, Color color)
 		{
 			this.offsets = offsets;
 			this.zOffset = zOffset;
@@ -37,16 +37,16 @@ namespace OpenRA.Mods.Kknd.Graphics
 
 		public IRenderable WithPalette(PaletteReference newPalette) { return this; }
 		public IRenderable WithZOffset(int newOffset) { return new LaserRenderable(offsets, newOffset, width, color); }
-		public IRenderable OffsetBy(WVec vec) { return this; } // TODO this one is wrong
+		public IRenderable OffsetBy(WVec vec) { return new LaserRenderable(offsets.Select(offset => offset + vec).ToArray(), zOffset, width, color); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
+			// TODO fix connectSegments - asin smoothen the edge of a break!
 			var screenWidth = wr.ScreenVector(new WVec(width, WDist.Zero, WDist.Zero))[0];
 
-			// TODO fix connectSegments!
-			Game.Renderer.WorldRgbaColorRenderer.DrawLine(offsets.Select(offset => wr.Screen3DPosition(new WPos(offset.X, offset.Y, 0))), screenWidth, color, false);
+			Game.Renderer.WorldRgbaColorRenderer.DrawLine(offsets.Select(offset => wr.Screen3DPosition(offset)), screenWidth, color, false);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr) { }

--- a/OpenRA.Mods.Kknd/Projectiles/Laser.cs
+++ b/OpenRA.Mods.Kknd/Projectiles/Laser.cs
@@ -15,115 +15,143 @@ using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Kknd.Graphics;
+using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Kknd.Projectiles
 {
-    [Desc("A beautiful generated laser beam.")]
-    public class LaserInfo : IProjectileInfo
-    {
-        [Desc("The maximum duration (in ticks) of the beam's existence.")]
-        public readonly int Duration = 10;
+	[Desc("A beautiful generated laser beam.")]
+	public class LaserInfo : IProjectileInfo
+	{
+		[Desc("The maximum duration (in ticks) of the beam's existence.")]
+		public readonly int Duration = 10;
 
-        [Desc("Color of the beam. Default falls back to player color.")]
-        public readonly Color Color = Color.Transparent;
+		[Desc("Color of the beam. Default falls back to player color.")]
+		public readonly Color Color = Color.Transparent;
 
-        [Desc("Inner lightness of the beam.")]
-        public readonly byte InnerLightness = 0xff;
+		[Desc("Inner lightness of the beam.")]
+		public readonly byte InnerLightness = 0xff;
 
-        [Desc("Outer lightness of the beam.")]
-        public readonly byte OuterLightness = 0x80;
+		[Desc("Outer lightness of the beam.")]
+		public readonly byte OuterLightness = 0x80;
 
-        [Desc("The radius of the beam.")]
-        public readonly int Radius = 3;
+		[Desc("The radius of the beam.")]
+		public readonly int Radius = 3;
 
-        [Desc("Disortion offset.")]
-        public readonly int Distortion = 0;
+		[Desc("Distortion offset.")]
+		public readonly int Distortion = 0;
 
-        [Desc("Disortion animation offset.")]
-        public readonly int DistortionAnimation = 0;
+		[Desc("Distortion animation offset.")]
+		public readonly int DistortionAnimation = 0;
 
-        [Desc("Maximum length per segment.")]
-        public readonly int SegmentLength = 0;
+		[Desc("Maximum length per segment.")]
+		public readonly WDist SegmentLength = WDist.Zero;
 
-        [Desc("Equivalent to sequence ZOffset. Controls Z sorting.")]
-        public readonly int ZOffset = 0;
+		[Desc("Equivalent to sequence ZOffset. Controls Z sorting.")]
+		public readonly int ZOffset = 0;
 
-        public IProjectile Create(ProjectileArgs args) { return new Laser(args, this); }
-    }
+		public IProjectile Create(ProjectileArgs args) { return new Laser(args, this); }
+	}
 
-    public class Laser : IProjectile
-    {
-        private readonly LaserInfo info;
-        private readonly Color[] colors;
-        private readonly int2[] offsets;
+	public class Laser : IProjectile
+	{
+		readonly LaserInfo info;
+		readonly Color[] colors;
+		readonly WPos[] offsets;
 
-        private int ticks;
+		readonly WVec leftVector;
+		readonly WVec upVector;
+		readonly MersenneTwister random;
 
-        public Laser(ProjectileArgs args, LaserInfo info)
-        {
-            this.info = info;
+		int ticks;
 
-            colors = new Color[info.Radius];
-            for (var i = 0; i < info.Radius; i++)
-            {
-                var color = info.Color == Color.Transparent ? args.SourceActor.Owner.Color.RGB : info.Color;
-                var bw = (float)((info.InnerLightness - info.OuterLightness) * i / (info.Radius - 1) + info.OuterLightness) / 0xff;
-                var dstR = bw > .5 ? 1 - (1 - 2 * (bw - .5)) * (1 - (float)color.R / 0xff) : 2 * bw * ((float)color.R / 0xff);
-                var dstG = bw > .5 ? 1 - (1 - 2 * (bw - .5)) * (1 - (float)color.G / 0xff) : 2 * bw * ((float)color.G / 0xff);
-                var dstB = bw > .5 ? 1 - (1 - 2 * (bw - .5)) * (1 - (float)color.B / 0xff) : 2 * bw * ((float)color.B / 0xff);
-                colors[i] = Color.FromArgb((int)(dstR * 0xff), (int)(dstG * 0xff), (int)(dstB * 0xff));
-            }
+		public Laser(ProjectileArgs args, LaserInfo info)
+		{
+			this.info = info;
 
-            var direction = args.PassiveTarget - args.Source;
-            if (this.info.SegmentLength == 0)
-            {
-                offsets = new[] { new int2(args.Source.X, args.Source.Y), new int2(args.PassiveTarget.X, args.PassiveTarget.Y) };
-            }
-            else
-            {
-                var numSegments = (direction.Length - 1) / info.SegmentLength + 1;
-                offsets = new int2[numSegments + 1];
-                offsets[0] = new int2(args.Source.X, args.Source.Y);
-                offsets[offsets.Length - 1] = new int2(args.PassiveTarget.X, args.PassiveTarget.Y);
+			colors = new Color[info.Radius];
+			for (var i = 0; i < info.Radius; i++)
+			{
+				var color = info.Color == Color.Transparent ? args.SourceActor.Owner.Color.RGB : info.Color;
+				var bw = (float)((info.InnerLightness - info.OuterLightness) * i / (info.Radius - 1) + info.OuterLightness) / 0xff;
+				var dstR = bw > .5 ? 1 - (1 - 2 * (bw - .5)) * (1 - (float)color.R / 0xff) : 2 * bw * ((float)color.R / 0xff);
+				var dstG = bw > .5 ? 1 - (1 - 2 * (bw - .5)) * (1 - (float)color.G / 0xff) : 2 * bw * ((float)color.G / 0xff);
+				var dstB = bw > .5 ? 1 - (1 - 2 * (bw - .5)) * (1 - (float)color.B / 0xff) : 2 * bw * ((float)color.B / 0xff);
+				colors[i] = Color.FromArgb((int)(dstR * 0xff), (int)(dstG * 0xff), (int)(dstB * 0xff));
+			}
 
-                for (var i = 1; i < numSegments; i++)
-                {
-                    var segmentStart = direction / numSegments * i;
-                    offsets[i] = new int2(args.Source.X + segmentStart.X, args.Source.Y + segmentStart.Y);
+			var direction = args.PassiveTarget - args.Source;
+
+			if (info.Distortion != 0 || info.DistortionAnimation != 0)
+			{
+				leftVector = new WVec(direction.Y, -direction.X, 0);
+				leftVector = 1024 * leftVector / leftVector.Length;
+
+				upVector = new WVec(
+					-direction.X * direction.Z,
+					-direction.Z * direction.Y,
+					direction.X * direction.X + direction.Y * direction.Y);
+				upVector = 1024 * upVector / upVector.Length;
+
+				random = args.SourceActor.World.SharedRandom;
+			}
+
+			if (this.info.SegmentLength == WDist.Zero)
+			{
+				offsets = new[] { args.Source, args.PassiveTarget };
+			}
+			else
+			{
+				var numSegments = (direction.Length - 1) / info.SegmentLength.Length + 1;
+				offsets = new WPos[numSegments + 1];
+				offsets[0] = args.Source;
+				offsets[offsets.Length - 1] = args.PassiveTarget;
+
+				for (var i = 1; i < numSegments; i++)
+				{
+					var segmentStart = direction / numSegments * i;
+					offsets[i] = args.Source + segmentStart;
 
 					if (info.Distortion != 0)
-                    {
-                        offsets[i] = new int2(
-                            offsets[i].X + Game.CosmeticRandom.Next(-info.Distortion / 2, info.Distortion / 2),
-                            offsets[i].Y + Game.CosmeticRandom.Next(-info.Distortion / 2, info.Distortion / 2));
-                    }
-                }
-            }
+					{
+						var angle = WAngle.FromDegrees(random.Next(360));
+						var distortion = random.Next(info.Distortion);
 
-            args.Weapon.Impact(Target.FromPos(args.PassiveTarget), args.SourceActor, args.DamageModifiers);
-        }
+						var offset = distortion * angle.Cos() * leftVector / (1024 * 1024)
+							+ distortion * angle.Sin() * upVector / (1024 * 1024);
 
-        public void Tick(World world)
-        {
-            if (++ticks >= info.Duration)
-                world.AddFrameEndTask(w => w.Remove(this));
-            else if (info.DistortionAnimation != 0)
-            {
-                for (var i = 1; i < offsets.Length - 1; i++)
-                {
-                    offsets[i] = new int2(
-                        offsets[i].X + Game.CosmeticRandom.Next(-info.DistortionAnimation / 2, info.DistortionAnimation / 2),
-                        offsets[i].Y + Game.CosmeticRandom.Next(-info.DistortionAnimation / 2, info.DistortionAnimation / 2));
-                }
-            }
-        }
+						offsets[i] += offset;
+					}
+				}
+			}
 
-        public IEnumerable<IRenderable> Render(WorldRenderer worldRenderer)
-        {
-            for (var i = 0; i < offsets.Length - 1; i++)
-            for (var j = 0; j < info.Radius; j++)
-                yield return new LaserRenderable(offsets, info.ZOffset, new WDist(32 + (info.Radius - j - 1) * 64), colors[j]);
-        }
-    }
+			args.Weapon.Impact(Target.FromPos(args.PassiveTarget), args.SourceActor, args.DamageModifiers);
+		}
+
+		public void Tick(World world)
+		{
+			if (++ticks >= info.Duration)
+				world.AddFrameEndTask(w => w.Remove(this));
+			else if (info.DistortionAnimation != 0)
+			{
+				for (var i = 1; i < offsets.Length - 1; i++)
+				{
+					var angle = WAngle.FromDegrees(random.Next(360));
+					var distortion = random.Next(info.DistortionAnimation);
+
+					var offset = distortion * angle.Cos() * leftVector / (1024 * 1024)
+						+ distortion * angle.Sin() * upVector / (1024 * 1024);
+
+					offsets[i] += offset;
+				}
+			}
+		}
+
+		public IEnumerable<IRenderable> Render(WorldRenderer worldRenderer)
+		{
+			for (var i = 0; i < offsets.Length - 1; i++)
+				for (var j = 0; j < info.Radius; j++)
+					yield return new LaserRenderable(offsets, info.ZOffset, new WDist(32 + (info.Radius - j - 1) * 64), colors[j]);
+		}
+	}
 }


### PR DESCRIPTION
No longer ignores height.
Use WDist for SegmentLength.
Fix LaserRenderable.OffsetBy.
Recode the math behind distortion.
Clarify a TODO comment.
Remove unnecessary private definitions.
And fix a typo.

Also, VS fixed the spaces/tabs mixup so I advise you to use ?w=1 on the diff.