### PR TITLE
Added missing Researchable trait's conditions for buildings

### DIFF
--- a/mods/kknd1/actors/evolved/buildings/alchemyhall/rules.yaml
+++ b/mods/kknd1/actors/evolved/buildings/alchemyhall/rules.yaml
@@ -2,6 +2,7 @@ evolved_building_alchemyhall:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^researches_buildings
 	Inherits@3: ^animated_building
+	Inherits@4: ^researchable
 	Tooltip:
 		Name: Alchemy Hall
 	Valued:

--- a/mods/kknd1/actors/evolved/buildings/beastenclosure/rules.yaml
+++ b/mods/kknd1/actors/evolved/buildings/beastenclosure/rules.yaml
@@ -2,6 +2,7 @@ evolved_building_beastenclosure:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^produces_vehicles
 	Inherits@3: ^animated_building
+	Inherits@4: ^researchable
 	Tooltip:
 		Name: Beast Enclosure
 	TooltipDescription:

--- a/mods/kknd1/actors/evolved/buildings/beastforge/rules.yaml
+++ b/mods/kknd1/actors/evolved/buildings/beastforge/rules.yaml
@@ -2,6 +2,7 @@ evolved_building_beastforge:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^produces_vehicles
 	Inherits@3: ^animated_building
+	Inherits@4: ^researchable
 	Tooltip:
 		Name: Beast Forge
 	TooltipDescription:

--- a/mods/kknd1/actors/evolved/buildings/blacksmith/rules.yaml
+++ b/mods/kknd1/actors/evolved/buildings/blacksmith/rules.yaml
@@ -2,6 +2,7 @@ evolved_building_blacksmith:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^produces_vehicles
 	Inherits@3: ^animated_building
+	Inherits@4: ^researchable
 	Tooltip:
 		Name: Blacksmith
 	Valued:

--- a/mods/kknd1/actors/evolved/buildings/clanhall/rules.yaml
+++ b/mods/kknd1/actors/evolved/buildings/clanhall/rules.yaml
@@ -2,6 +2,7 @@ evolved_building_clanhall:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^produces_buildings
 	Inherits@3: ^animated_building
+	Inherits@4: ^researchable
 	Tooltip:
 		Name: Clanhall
 	Valued:

--- a/mods/kknd1/actors/evolved/buildings/menagerie/rules.yaml
+++ b/mods/kknd1/actors/evolved/buildings/menagerie/rules.yaml
@@ -1,6 +1,7 @@
 evolved_building_menagerie:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^repairs_vehicles
+	Inherits@3: ^researchable
 	Tooltip:
 		Name: Menagerie
 	Valued:

--- a/mods/kknd1/actors/evolved/buildings/powerstation/rules.yaml
+++ b/mods/kknd1/actors/evolved/buildings/powerstation/rules.yaml
@@ -2,6 +2,7 @@ evolved_building_powerstation:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^processes_oil
 	Inherits@3: ^animated_building
+	Inherits@4: ^researchable
 	Tooltip:
 		Name: Power Station
 	Valued:

--- a/mods/kknd1/actors/evolved/buildings/warriorhall/rules.yaml
+++ b/mods/kknd1/actors/evolved/buildings/warriorhall/rules.yaml
@@ -1,6 +1,7 @@
 evolved_building_warriorhall:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^produces_infantry
+	Inherits@3: ^researchable
 	Tooltip:
 		Name: Warrior Hall
 	Valued:

--- a/mods/kknd1/actors/survivors/buildings/barracks/rules.yaml
+++ b/mods/kknd1/actors/survivors/buildings/barracks/rules.yaml
@@ -2,6 +2,7 @@ survivors_building_barracks:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^produces_infantry
 	Inherits@3: ^animated_building
+	Inherits@4: ^researchable
 	Tooltip:
 		Name: Barracks
 	Valued:

--- a/mods/kknd1/actors/survivors/buildings/machineshop/rules.yaml
+++ b/mods/kknd1/actors/survivors/buildings/machineshop/rules.yaml
@@ -2,6 +2,7 @@ survivors_building_machineshop:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^produces_vehicles
 	Inherits@3: ^animated_building
+	Inherits@4: ^researchable
 	Tooltip:
 		Name: Machine Shop
 	Valued:

--- a/mods/kknd1/actors/survivors/buildings/outpost/rules.yaml
+++ b/mods/kknd1/actors/survivors/buildings/outpost/rules.yaml
@@ -2,6 +2,7 @@ survivors_building_outpost:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^produces_buildings
 	Inherits@3: ^animated_building
+	Inherits@4: ^researchable
 	Tooltip:
 		Name: Outpost
 	Valued:

--- a/mods/kknd1/actors/survivors/buildings/powerstation/rules.yaml
+++ b/mods/kknd1/actors/survivors/buildings/powerstation/rules.yaml
@@ -2,6 +2,7 @@ survivors_building_powerstation:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^processes_oil
 	Inherits@3: ^animated_building
+	Inherits@4: ^researchable
 	Tooltip:
 		Name: Power Station
 	Valued:

--- a/mods/kknd1/actors/survivors/buildings/repairbay/rules.yaml
+++ b/mods/kknd1/actors/survivors/buildings/repairbay/rules.yaml
@@ -1,6 +1,7 @@
 survivors_building_repairbay:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^repairs_vehicles
+	Inherits@3: ^researchable
 	Tooltip:
 		Name: Repair Bay
 	Valued:

--- a/mods/kknd1/actors/survivors/buildings/researchlab/rules.yaml
+++ b/mods/kknd1/actors/survivors/buildings/researchlab/rules.yaml
@@ -2,6 +2,7 @@ survivors_building_researchlab:
 	Inherits@1: ^CoreBuilding
 	Inherits@2: ^researches_buildings
 	Inherits@3: ^animated_building
+	Inherits@4: ^researchable
 	Tooltip:
 		Name: Research Lab
 	Valued:

--- a/mods/kknd1/core/mod.yaml
+++ b/mods/kknd1/core/mod.yaml
@@ -16,10 +16,10 @@ Rules:
 	kknd1|core/rules/mechanics/produces_resources.yaml
 	kknd1|core/rules/mechanics/produces_vehicles.yaml
 	kknd1|core/rules/mechanics/repairs_vehicles.yaml
+	kknd1|core/rules/mechanics/researchable.yaml
 	kknd1|core/rules/mechanics/researches_buildings.yaml
 	kknd1|core/rules/mechanics/saboteur.yaml
 	kknd1|core/rules/mechanics/technician.yaml
-	kknd1|core/rules/mechanics/researchable.yaml
 
 Sequences:
 	kknd1|core/sequences/craters.yaml

--- a/mods/kknd1/core/mod.yaml
+++ b/mods/kknd1/core/mod.yaml
@@ -19,6 +19,7 @@ Rules:
 	kknd1|core/rules/mechanics/researches_buildings.yaml
 	kknd1|core/rules/mechanics/saboteur.yaml
 	kknd1|core/rules/mechanics/technician.yaml
+	kknd1|core/rules/mechanics/researchable.yaml
 
 Sequences:
 	kknd1|core/sequences/craters.yaml

--- a/mods/kknd1/core/rules/mechanics/researchable.yaml
+++ b/mods/kknd1/core/rules/mechanics/researchable.yaml
@@ -1,0 +1,3 @@
+^researchable:
+	Researchable:
+		RequiresCondition: !selfconstructing && !deconstructing


### PR DESCRIPTION
You could research buildings when they were being constructed or deconstructed. It should be fixed now.