### PR TITLE
Fixed wrong Barrage Craft projectile

### DIFF
--- a/mods/kknd1/actors/survivors/vehicles/barragecraft/sequences.yaml
+++ b/mods/kknd1/actors/survivors/vehicles/barragecraft/sequences.yaml
@@ -1,5 +1,7 @@
 survivors_vehicle_barragecraft:
-	projectile: SPRITES.LVL|BarrageCraft.mobd
+	projectile: SPRITES.LVL|Crab.mobd
+		Length: 2
+		Tick: 120
 		Facings: -16
 	turret: SPRITES.LVL|BarrageCraft.mobd
 		Start: 16


### PR DESCRIPTION
Barrage Craft does indeed have own projectile, but in the original KKND game, it uses Crab's projectile. Besides I believe this mistake was done when IceReaper was refactoring actors.